### PR TITLE
Twilio method api v2010 error

### DIFF
--- a/10_twilio/main.go
+++ b/10_twilio/main.go
@@ -25,7 +25,7 @@ func SendMessage(msg string) {
 	params.SetFrom(fromPhone)
 	params.SetBody(msg)
 
-	response, err := client.ApiV2010.CreateMessage(&params)
+	response, err := client.Api.CreateMessage(&params)
 	if err != nil {
 		fmt.Printf("error creating and sending message: %s\n", err.Error())
 		return


### PR DESCRIPTION
see the error when calling the method "ApiV2010" as shown in the image below:
![image](https://user-images.githubusercontent.com/19577746/174187471-0c0f330c-1eb0-4284-8af5-09b1afce7aac.png)

Resolve the issue by changing the call to` Api` instead of `ApiV2010`

![image](https://user-images.githubusercontent.com/19577746/174187775-c3753937-bb6f-41f7-9e4a-e0a3706232a3.png)
