### PR TITLE
Twilio undefined twilio rest client params

### DIFF
--- a/10_twilio/main.go
+++ b/10_twilio/main.go
@@ -46,7 +46,7 @@ func init() {
 	fromPhone = os.Getenv("FROM_PHONE")
 	toPhone = os.Getenv("TO_PHONE")
 
-	client = twilio.NewRestClientWithParams(twilio.RestClientParams{
+	client = twilio.NewRestClientWithParams(twilio.ClientParams{
 		Username: accountSid,
 		Password: authToken,
 	})

--- a/10_twilio/main.go
+++ b/10_twilio/main.go
@@ -25,7 +25,7 @@ func SendMessage(msg string) {
 	params.SetFrom(fromPhone)
 	params.SetBody(msg)
 
-	response, err := client.ApiV2010.CreateMessage(&params)
+	response, err := client.Api.CreateMessage(&params)
 	if err != nil {
 		fmt.Printf("error creating and sending message: %s\n", err.Error())
 		return


### PR DESCRIPTION
By changing the method **ApiV2010** the successive error as below:
![image](https://user-images.githubusercontent.com/19577746/174190041-818b28f1-59c5-457c-9517-60c05bae91e4.png)

The below diff helps resolve the issue:
![Error diff](https://user-images.githubusercontent.com/19577746/174190169-c80efbb8-92c2-492a-9342-e144edbfe675.png)

Corrected code:
`	client = twilio.NewRestClientWithParams(twilio.ClientParams{
		Username: accountSid,
		Password: authToken,`
